### PR TITLE
Add architecture and refactor documentation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,37 @@
+# Standdeff-Organizer Architekturüberblick
+
+## Zweck des Repos
+Das Projekt liefert ein Tampermonkey-Userscript, das an mehreren Stellen von *Die Stämme* (Massen-Unterstützen, Forum, Spieleinstellungen) zusätzliche UI- und Automatisierungsfunktionen anbietet. Der produktive Userscript-Code wird aus den TypeScript-Quellen unter `src/` kompiliert (siehe `devUserscript.js`).
+
+## Einstiegspunkt & Kontexte
+Der Einstiegspunkt `src/index.ts` registriert ein `$(document).ready`-Callback und ermittelt anhand der URL-Parameter den aktuellen Seitenkontext. Anschließend wird genau eine der vier UI-Routinen geladen:
+
+| Kontext (screen) | Einstiegsfunktion | Beschreibung |
+| --- | --- | --- |
+| `place` | `displayMassUt` (`src/ui/mass-ut.ts`) | Automatisiert Checkboxen im Massen-UT-Formular, setzt Filter/Gruppe/Vorlage und protokolliert verschickte Pakete pro SD-Thread. |
+| `forum-view_thread` | `viewThread` (`src/ui/view-thread.ts`) | Erkennt SD-Threads, ergänzt Buttons/Popups zum Registrieren neuer Threads und zeigt bei bekannten Threads die SD-Tabelle (`sdTable`) an. |
+| `forum-new_thread` | `createNewTable` (`src/ui/new-thread.ts`) | Stellt Eingabemasken für Paket-Vorlagen bereit und generiert beim Absenden den initialen Thread-Text inkl. SD-Tabelle und Spoiler-Erklärungen. |
+| `settings` | `displaySettings` (`src/ui/settings.ts`) | Rendert eine Konfigurations-Tabelle in den Spieleinstellungen, inkl. toggles, Dropdowns für Gruppen/Vorlagen und einer Liste aller bekannten SD-Threads. |
+
+> **Hinweis:** Jede dieser Funktionen kapselt den kompletten jQuery-Manipulationscode für ihren Kontext. Dadurch lässt sich das Script gezielt auf den Seiten aktivieren, auf denen Tampermonkey es injiziert.
+
+## Persistenz & Datenmodell
+Alle nutzerbezogenen Informationen (allgemeine Settings, bekannte Threads, Thread-spezifische Cache-Daten) werden über die Singleton-Klasse `LocalStorageHelper` verwaltet (`src/helpers/local-storage-helper.ts`).
+
+- Beim Instanziieren wird der Schlüssel `standdeff-organizer` aus dem LocalStorage geladen oder mit Default-Werten initialisiert.
+- Getter/Setter aktualisieren vor jedem Zugriff den lokalen Cache (`updateFromLocalStorage`) und serialisieren Maps zu Arrays, um sie persistieren zu können.
+- Thread-Daten bestehen aus Metadaten (`threadName`, `forumId`, `sdPostId`), einem Post-Cache für Bunkeranfragen sowie zwei Maps: `stateOfSdTable` (Stand der Tabellenzeilen, key = Dorf-ID) und `packagesSent` (gesendete Paketanzahl pro interner SD-ID).
+
+## Helfer & Komponenten
+- **Helper** (`src/helpers/`):
+  - `helper-functions.ts`: Utility-Funktionen rund um Thread-Erkennung, Parsing und DOM-Aktionen.
+  - `table-helper.ts`: Parsen von Posts/Tabelle zu Maps, Rendering der SD-Tabelle und Anwenden von Settings auf Massen-UT-Links.
+  - `tw-helper.ts`: Browser-spezifische Checks (z. B. ob der aktuelle Nutzer Forum-Mod ist) sowie Zugriff auf globale `game_data`.
+  - `logging-helper.ts`: Wrapper rund um `console` mit Level-Methoden.
+- **UI-Komponenten** (`src/ui/components/`): Teilroutinen, die innerhalb von `viewThread` eingebunden werden, z. B. Popups, Request-Formulare oder die Visualisierung/Edition der SD-Tabelle.
+
+## Build & Ausführung
+- **Entwicklung:** TypeScript-Quellen werden über webpack/babel gebündelt. `npm run dev` baut `devUserscript.js`, welches direkt in Tampermonkey importiert werden kann.
+- **Produktion:** Tampermonkey führt ausschließlich die gebaute Datei aus; alle TypeScript/ES-Modul-Features werden während des Builds transpiliert.
+
+Dieses Dokument dient als Ausgangspunkt, wenn neue Contributor:innen sich schnell orientieren oder weitere Kontexte ergänzen möchten.

--- a/docs/refactor-ideas.md
+++ b/docs/refactor-ideas.md
@@ -1,0 +1,23 @@
+# Refactor-Vorschläge
+
+Die folgenden Punkte sind bei der Analyse der aktuellen Codebasis aufgefallen und könnten in künftigen Iterationen adressiert werden.
+
+## 1. Kontext-spezifische Controller verkleinern
+- **Problem:** Dateien wie `src/ui/mass-ut.ts` oder `src/ui/settings.ts` enthalten jeweils 200+ Zeilen mit Inline-jQuery-Manipulationen. Das erschwert Tests und Wiederverwendung.
+- **Idee:** Aufbrechen in kleinere Service-Klassen (z. B. `MassUtSelectionService`, `SettingsViewModel`), die nur Daten vorbereiten, während dedizierte Renderer die DOM-Strukturen erzeugen. Dadurch lassen sich Kernfunktionen einfacher unit-testen und zukünftige Layout-Änderungen isolieren.
+
+## 2. Template-Strings auslagern
+- **Problem:** `src/ui/new-thread.ts` enthält lange Template-Strings (mehrere hundert Zeilen) für den initialen Forenbeitrag. Bereits kleine Textänderungen erzeugen unübersichtliche Diffs und erhöhen die Gefahr von Tippfehlern.
+- **Idee:** Die Textbausteine in eigene Markdown/BBCode-Dateien unter `src/assets/` auslagern und beim Build via `raw-loader` importieren. Alternativ könnte ein JSON-Template genutzt werden, das die Paketzeilen dynamisch injiziert. So bleibt der TypeScript-Code schlanker und Übersetzer:innen können Texte leichter anpassen.
+
+## 3. LocalStorage-Serialisierung vereinheitlichen
+- **Problem:** `LocalStorageHelper` konvertiert Maps an mehreren Stellen manuell zu Arrays und zurück. Änderungen am Schema müssen an vielen Methoden vorgenommen werden.
+- **Idee:** Ein generischer Serializer (z. B. `mapToRecord`, `recordToMap`) oder eine kleine ORM-ähnliche Schicht würde die Konvertierung zentralisieren. Ergänzend könnten Zod/TypeBox-Schemas validieren, ob LocalStorage-Daten die erwartete Struktur haben, bevor sie benutzt werden.
+
+## 4. Events statt Polling
+- **Problem:** Komponenten wie `sd-table.ts` registrieren einen globalen `storage`-Listener und müssen dann das komplette DOM neu parsen, wenn sich etwas ändert.
+- **Idee:** Ein internes Event-Bus-Modul (z. B. via `mitt` oder eine simple Custom-Event-Implementation) könnte gezielt Signale ("Pakete aktualisiert", "Thread hinzugefügt") verschicken. Dadurch lassen sich DOM-Updates auf die tatsächlich betroffenen Bereiche beschränken, was Performance und Lesbarkeit verbessert.
+
+## 5. Typsichere DOM-Zugriffe
+- **Problem:** Viele Selektoren werden mehrfach wiederholt (z. B. `$(".clearfix > form > input[value=Senden]")`). Ein Tippfehler bleibt unbemerkt, bis Tampermonkey die Seite lädt.
+- **Idee:** Konstanten für wiederkehrende Selektoren oder kleine Wrapper-Komponenten ("`ForumForm`", "`MassUtForm`") würden Redundanzen verringern. In Kombination mit `data-*`-Attributen auf eigenen Elementen könnte man sogar auf fragile Struktur-Selektoren verzichten.

--- a/docs/ui-components.md
+++ b/docs/ui-components.md
@@ -1,0 +1,40 @@
+# UI-Komponenten & Verantwortlichkeiten
+
+Dieses Dokument fasst zusammen, welche UI-Bausteine in welchem Kontext greifen und wie sie zusammenspielen.
+
+## Kontext-spezifische Controller
+
+### `displayMassUt` (`src/ui/mass-ut.ts`)
+- Läuft ausschließlich auf `screen=place` und initialisiert beim Laden sofort `storeGroupData` und `storeTemplateData`, um aktuelle Gruppen/Vorlagen für spätere Settings bereitzustellen.
+- Liest `sdTableId`, Ziel-Dorf (`target`) sowie Einstellungen wie `getPreventDuplicateDestination` oder `getAutomateMassenUt` aus dem `LocalStorageHelper`.
+- Wählt automatisch die passende Vorlage im Dropdown, setzt Checkboxen für Truppenanfragen und verhindert (je nach Einstellung) Doppel-Sendungen, indem gesendete Pakete im `ThreadData.packagesSent`-Map aktualisiert werden.
+
+### `viewThread` (`src/ui/view-thread.ts`)
+- Erkennt nach dem Laden, ob gerade ein neuer SD-Thread erstellt wurde (`getNewThread`). Falls ja, werden Thread-Metadaten zusammen mit der `sdPostId` über `addThreadIdToLocalStorage` persistiert.
+- Prüft anhand des LocalStorage, ob das aktuelle `thread_id` bekannt ist.
+  - **Bekannt:** Rendert die Tabellenansicht über `sdTable(threads)`.
+  - **Unbekannt:** Zeigt ein Popup (`addSdPopup`) bzw. Optionselemente (`addSdOptions`), damit Nutzer:innen den Thread als SD-Thread markieren können.
+
+### `createNewTable` (`src/ui/new-thread.ts`)
+- Nur für Forum-Moderator:innen aktiv. Fügt neben der Thread-Überschrift einen Konfigurationsbutton ein, der Eingabefelder für Standard-Paketgrößen (Speer, Schwert, Bogenschütze, Späher) anzeigt.
+- `newThread()` sammelt die Eingaben, setzt Defaultwerte falls alles leer ist, generiert daraus `[unit]`-Zeilen und ersetzt den Post-Inhalt durch einen vorgefertigten Block (inkl. Tabelle, Spoiler-Erklärungen und PostCache-Sektion).
+- Beim Absenden wird `setNewThread = true` gesetzt, sodass `viewThread` im Anschluss die `sdPostId` auslesen kann.
+
+### `displaySettings` (`src/ui/settings.ts`)
+- Rendert eine Settings-Tabelle in den Spieleinstellungen und spiegelt alle Flags aus `LocalStorageHelper.generalSettings` wider.
+- Falls bereits Gruppen- oder Vorlagen-Daten aus Massen-UT eingelesen wurden, werden die numerischen Inputs durch Dropdowns ersetzt.
+- Listet alle bekannten Threads (`getAllThreads`) inklusive Link und Delete-Button.
+- Registriert Event-Listener für alle Buttons/Inputs, die den LocalStorage unmittelbar aktualisieren (z. B. `setAutomateMassenUt`, `setSdGroupId`, `setSelectedTemplate`).
+
+## Komponenten innerhalb von `viewThread`
+
+| Datei | Kurzbeschreibung |
+| --- | --- |
+| `components/sd-table.ts` | Kernansicht der SD-Tabelle: parst Posts (`parseSdPosts`), synchronisiert den lokalen Cache (`setSdTableState`), aktualisiert Paketstände (`displayUpdatedSdTable`, `updateSentPackagesInSdTable`) und blendet moderationsspezifische Aktionen ein/aus. |
+| `components/edit-sd-post.ts` | Unterstützt Moderator:innen beim Aktualisieren des Original-SD-Posts, indem bestehende Werte in das Formular geschrieben werden. |
+| `components/request-popup.ts` | UI für neue Bunkeranfragen, inkl. Validierung, Parsing der Koordinaten und Bulk-Editing-Funktionen. |
+| `components/post-layout.ts` | Ersetzt oder blockiert Textareas für Nicht-Admins, fügt Buttons für die Bunkeranfragen-Bearbeitung ein und verhindert versehentliche Änderungen. |
+| `components/options-sd-thread.ts` | Bindet Buttons an unbekannte Threads, um sie als SD-Thread zu registrieren oder aus der Liste zu entfernen. |
+| `components/first-start-thread-popup.ts` | Popup beim ersten Start, das erklärt, wie Threads verknüpft werden; abhängig vom Setting `firstStartPopup`.
+
+> Die Komponenten greifen intensiv auf Hilfsfunktionen aus `src/helpers/table-helper.ts` sowie `LocalStorageHelper` zu, sodass die Tabelle immer denselben Stand zwischen Forum und Massen-UT hat.


### PR DESCRIPTION
## Summary
- add an architecture overview that explains the Tampermonkey contexts, helper modules, and build process
- document the responsibilities of the UI controllers and reusable components
- capture concrete refactor ideas for simplifying controllers, templates, and storage serialization

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917177d565c832da8de995e6f5d8b01)